### PR TITLE
enable internal dns resolution in the aws vpc

### DIFF
--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -14,6 +14,7 @@ variable "ssh_key" {default = "~/.ssh/id_rsa.pub"}
 
 resource "aws_vpc" "main" {
   cidr_block = "${var.network_ipv4}"
+  enable_dns_hostnames = true
   tags {
     Name = "${var.long_name}"
   }


### PR DESCRIPTION
I found I had to enable dns hostnames in the aws vpc in order for internal name resolution to work correctly
